### PR TITLE
Update Multi-GPU_Training.ipynb

### DIFF
--- a/caffe2/python/tutorials/Multi-GPU_Training.ipynb
+++ b/caffe2/python/tutorials/Multi-GPU_Training.ipynb
@@ -212,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Part 4: Image Transformations\n",
+    "## Part 4: Image Transformations (requires Caffe2 to be compiled with opencv)\n",
     "\n",
     "Now that we have a reader we should take a look at how we're going to process the images. Since images that are found in the wild can be wildly different sizes, aspect ratios, and orientations we can and should train on as much variety as we can. ImageNet is no exception here. The average resolution is 496x387, and as interesting as that factoid might be, the bottom line is that you have a lot of variation. \n",
     "\n",
@@ -243,6 +243,8 @@
     "        scale=256,\n",
     "        # crop to the square each image to exact dimensions\n",
     "        crop=224,\n",
+    "        # not running in test mode\n",
+    "        is_test=False,\n",
     "        # mirroring of the images will occur randomly\n",
     "        mirror=1\n",
     "    )\n",


### PR DESCRIPTION
Made it clear that opencv is required for ImageInput which is a common question on github & fixed a bug in the multigpu tutorial.